### PR TITLE
refactor(k8s): mount secrets instead of passing them as env

### DIFF
--- a/kubernetes/api-deployment.yml
+++ b/kubernetes/api-deployment.yml
@@ -105,6 +105,7 @@ spec:
           persistentVolumeClaim:
             claimName: shared
         - name: secrets
+          # 'projected' allows multiple sources to be combined into a single volume
           projected:
             sources:
             - secret:

--- a/kubernetes/api-deployment.yml
+++ b/kubernetes/api-deployment.yml
@@ -21,6 +21,9 @@ spec:
           volumeMounts:
             - mountPath: /shared
               name: shared
+            - mountPath: /var/run/secrets
+              name: secrets
+              readOnly: true
           resources:
             requests:
               memory: "512Mi"
@@ -79,41 +82,6 @@ spec:
                 configMapKeyRef:
                   name: avatar-config
                   key: DB_PORT
-            - name: DB_USER
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: username
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: password
-            - name: PEPPER
-              valueFrom:
-                secretKeyRef:
-                  name: api
-                  key: pepper
-            - name: AUTHJWT_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: api
-                  key: authjwt_secret_key
-            - name: FILE_ENCRYPTION_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: api
-                  key: file_encryption_key
-            - name: AVATAR_FIRST_USER_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: api
-                  key: avatar_first_user_password
-            - name: AVATAR_FIRST_USER_NAME
-              valueFrom:
-                configMapKeyRef:
-                  name: avatar-config
-                  key: AVATAR_FIRST_USER_NAME
             - name: TASK_MAX_TIME_LIMIT
               valueFrom:
                 configMapKeyRef:
@@ -136,3 +104,11 @@ spec:
         - name: shared
           persistentVolumeClaim:
             claimName: shared
+        - name: secrets
+          projected:
+            sources:
+            - secret:
+                name: api
+            - secret:
+                name: postgres-secret
+      

--- a/kubernetes/api-secrets.template.yml
+++ b/kubernetes/api-secrets.template.yml
@@ -14,3 +14,4 @@ stringData:
   file_encryption_key: TODO
   # python -c "import secrets; print(secrets.token_hex(), end='')"
   avatar_first_user_password: TODO
+  avatar_first_user_name: TODO

--- a/kubernetes/config-map.yml
+++ b/kubernetes/config-map.yml
@@ -16,6 +16,4 @@ data:
   # Set to externally accessible API url (should be with https)
   BASE_API_URL: http://api.octopize.local:8000
   PDFGENERATOR_URL: http://pdfgenerator:8001/
-  # Set to name of first user
-  AVATAR_FIRST_USER_NAME: avatar_admin
   TASK_MAX_TIME_LIMIT: ""

--- a/kubernetes/pdfgenerator-deployment.yml
+++ b/kubernetes/pdfgenerator-deployment.yml
@@ -22,3 +22,4 @@ spec:
             - containerPort: 8000
       imagePullSecrets:
         - name: docker-local-pull-secret
+  

--- a/kubernetes/postgres-deployment.yml
+++ b/kubernetes/postgres-deployment.yml
@@ -20,6 +20,12 @@ spec:
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 5432
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: postgres-data
+            - mountPath: /var/run/secrets
+              name: secrets
+              readOnly: true
           resources:
             requests:
               memory: "1Gi"
@@ -28,11 +34,6 @@ spec:
               memory: "2Gi"
               cpu: "1000m"
           env:
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: password
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
@@ -43,10 +44,13 @@ spec:
                 secretKeyRef:
                   name: postgres-secret
                   key: dbname
-          volumeMounts:
-            - mountPath: /var/lib/postgresql/data
-              name: postgres-data
+
       volumes:
         - name: postgres-data
           persistentVolumeClaim:
             claimName: postgres-pv-claim
+        - name: secrets
+          projected:
+            sources:
+            - secret:
+                name: postgres-secret

--- a/kubernetes/postgres-deployment.yml
+++ b/kubernetes/postgres-deployment.yml
@@ -34,27 +34,18 @@ spec:
               memory: "2Gi"
               cpu: "1000m"
           env:
-          # Postgres needs these values to be passed as env variables to create the database,
-          # so we can't mount a volume
             - name: POSTGRES_PASSWORD_FILE
-              value: /var/run/secrets/db_password #where the secrets volume is mounted
-            - name: POSTGRES_USER
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: db_user
-            - name: POSTGRES_DB
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: db_name
+              value: /var/run/secrets/db_password
+            - name: POSTGRES_USER_FILE
+              value: /var/run/secrets/db_user
+            - name: POSTGRES_DB_FILE
+              value: /var/run/secrets/db_name
+
 
       volumes:
         - name: postgres-data
           persistentVolumeClaim:
             claimName: postgres-pv-claim
         - name: secrets
-          projected:
-            sources:
-            - secret:
-                name: postgres-secret
+          secret:
+            secretName: postgres-secret

--- a/kubernetes/postgres-deployment.yml
+++ b/kubernetes/postgres-deployment.yml
@@ -34,16 +34,20 @@ spec:
               memory: "2Gi"
               cpu: "1000m"
           env:
+          # Postgres needs these values to be passed as env variables to create the database,
+          # so we can't mount a volume
+            - name: POSTGRES_PASSWORD_FILE
+              value: /var/run/secrets/db_password #where the secrets volume is mounted
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
                   name: postgres-secret
-                  key: username
+                  key: db_user
             - name: POSTGRES_DB
               valueFrom:
                 secretKeyRef:
                   name: postgres-secret
-                  key: dbname
+                  key: db_name
 
       volumes:
         - name: postgres-data

--- a/kubernetes/postgres-secrets.template.yml
+++ b/kubernetes/postgres-secrets.template.yml
@@ -9,4 +9,4 @@ stringData:
   dbname: avatar
   username: avatar
   # python -c "import secrets; print(secrets.token_hex(), end='')"
-  password: TODO
+  db_password: TODO

--- a/kubernetes/postgres-secrets.template.yml
+++ b/kubernetes/postgres-secrets.template.yml
@@ -6,7 +6,7 @@ metadata:
 type: Opaque
 
 stringData:
-  dbname: avatar
-  username: avatar
+  db_name: avatar
+  db_user: avatar
   # python -c "import secrets; print(secrets.token_hex(), end='')"
   db_password: TODO

--- a/kubernetes/worker-deployment.yml
+++ b/kubernetes/worker-deployment.yml
@@ -22,6 +22,9 @@ spec:
           volumeMounts:
             - mountPath: /shared
               name: shared
+            - mountPath: /var/run/secrets
+              name: secrets
+              readOnly: true
           resources:
             requests:
               memory: "4Gi"
@@ -80,29 +83,17 @@ spec:
                 configMapKeyRef:
                   name: avatar-config
                   key: DB_PORT
-            - name: DB_USER
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: username
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: password
-            - name: FILE_ENCRYPTION_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: api
-                  key: file_encryption_key
-            - name: AVATAR_FIRST_USER_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: api
-                  key: avatar_first_user_password
       imagePullSecrets:
         - name: docker-local-pull-secret
       volumes:
         - name: shared
           persistentVolumeClaim:
             claimName: shared
+        - name: secrets
+          projected:
+            sources:
+            - secret:
+                name: api
+            - secret:
+                name: postgres-secret
+      

--- a/kubernetes/worker-deployment.yml
+++ b/kubernetes/worker-deployment.yml
@@ -94,6 +94,18 @@ spec:
             sources:
             - secret:
                 name: api
+                # We use items as we don't want to put every single secret for the worker container
+                items:
+                - key: avatar_first_user_password
+                  path: avatar_first_user_password # path is required no matter what
+                - key: file_encryption_key
+                  path: file_encryption_key
             - secret:
                 name: postgres-secret
-      
+                items:
+                - key: db_password
+                  path: db_password
+                - key: db_user  
+                  path: db_user
+                - key: db_name  
+                  path: db_name


### PR DESCRIPTION
This changes mounts the secrets to `/var/run/secrets`, where our `docker-compose.yml` file usually takes them, instead of passing them as environment variables which we could mistakenly print inadvertently.

We won't use raw Kubernetes files going forward (we'd rather use Helm), but this was useful for testing. I'll be implementing this change in the Helm files too.