### PR TITLE
fix: add more memory to worker deployment

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -6,6 +6,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 icon: https://octopize-md.com/wp-content/uploads/2021/07/cropped-picto-octopize-32x32.png

--- a/helm-chart/templates/worker-deployment.yaml
+++ b/helm-chart/templates/worker-deployment.yaml
@@ -29,8 +29,8 @@ spec:
           command: ["celery", "-A", "api.lib.task", "worker", "--loglevel=info"]
           resources:
             requests:
-              memory: "4Gi"
-              cpu: "2000m"
+              memory: "32Gi"
+              cpu: "4000m"
             limits:
               memory: "32Gi"
               cpu: "4000m"

--- a/launch_helm.sh
+++ b/launch_helm.sh
@@ -130,6 +130,8 @@ cmd=(helm "$subcommand" --debug "$release_name" ./helm-chart --namespace "$names
       --set avatarVersion="$avatar_version" \
       --set pdfgeneratorVersion="$pdfgenerator_version" \
       --set api.useEmailAuthentication="$use_email_auth" \
+      --set api.isTelemetryEnabled="false" \
+      --set api.isSentryEnabled="false" \
 )
 
 if [ "$use_email_auth" = "false" ]; then


### PR DESCRIPTION
On our current implementation on the cloud, the default is to take the value in `request`. As the auto-scaling is not fully featured, the values in `limits` are never reached. Which is why we change it for now.