### PR TITLE
fix: add group_id env variable in deployment config

### DIFF
--- a/docker/docker-compose.sh
+++ b/docker/docker-compose.sh
@@ -15,6 +15,8 @@ set -x
 
 
 export USER_ID=${USER_ID-$(id -u)}
+export GROUP_ID=${GROUP_ID-$(id -g)}
+
 export SECRETS_DIR="${SECRETS_DIR:-.secrets}"
 export AVATAR_API_VERSION=${AVATAR_API_VERSION-latest}
 export AVATAR_PDFGENERATOR_VERSION=${AVATAR_PDFGENERATOR_VERSION-latest}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,6 +38,8 @@ services:
       IS_TELEMETRY_ENABLED: ${IS_TELEMETRY_ENABLED}
       IS_SENTRY_ENABLED: ${IS_SENTRY_ENABLED}
       USER_ID: ${USER_ID} # user id of the user executing the container
+      GROUP_ID: ${GROUP_ID} # group id of the user executing the container
+
 
     secrets:
       - db_name
@@ -80,6 +82,7 @@ services:
       IS_TELEMETRY_ENABLED: ${IS_TELEMETRY_ENABLED}
       IS_SENTRY_ENABLED: ${IS_SENTRY_ENABLED}
       USER_ID: ${USER_ID} # user id of the user executing the container
+      GROUP_ID: ${GROUP_ID} # group id of the user executing the container
       # SHARED_STORAGE_PATH should only be set when using non-filesystem based storage.
       # It's best to let the API choose the default location for filesystem storage
       # on the container.
@@ -118,6 +121,7 @@ services:
       IS_SENTRY_ENABLED: ${IS_SENTRY_ENABLED}
       SHARED_STORAGE_PATH: ${SHARED_STORAGE_PATH}
       USER_ID: ${USER_ID} # user id of the user executing the container
+      GROUP_ID: ${GROUP_ID} # group id of the user executing the container
 
   db:
     image: postgres:14.0

--- a/helm-chart/templates/api-deployment.yaml
+++ b/helm-chart/templates/api-deployment.yaml
@@ -85,6 +85,8 @@ spec:
             {{ if .Values.debug.storage.useLocal }}
             - name: USER_ID
               value: "1000"
+            - name: GROUP_ID
+              value: "1000"
             {{ end }}
           ports:
             - name: api

--- a/helm-chart/templates/worker-deployment.yaml
+++ b/helm-chart/templates/worker-deployment.yaml
@@ -71,6 +71,8 @@ spec:
             {{ if .Values.debug.storage.useLocal }}
             - name: USER_ID
               value: "1000"
+            - name: GROUP_ID
+              value: "1000"
             {{ end }}
       imagePullSecrets:
         - name: docker-local-pull-secret


### PR DESCRIPTION
I did propagate the fix from avatar.git/branch/yk/fix-entrypoint here as there is changes in docker-compose.

The idea is to be able to overwrite the group_id in order to access to shared data using groups accesses.