### PR TITLE
feat(helm): allow passing in tolerations per deployment

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -6,6 +6,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.9
+version: 0.2.10
 
 icon: https://octopize-md.com/wp-content/uploads/2021/07/cropped-picto-octopize-32x32.png

--- a/helm-chart/templates/api-deployment.yaml
+++ b/helm-chart/templates/api-deployment.yaml
@@ -18,6 +18,10 @@ spec:
         # Do not modify the following label without modifying the `podAffinity` of other objects.
         app.kubernetes.io/component: api
     spec:
+      {{- if .Values.api.tolerations }}
+      tolerations:
+        {{- toYaml .Values.api.tolerations | nindent 8 }}
+      {{ end -}}
       {{ if .Values.resources.apiPreferredNodeType }}
       affinity:
         nodeAffinity:

--- a/helm-chart/templates/pdfgenerator-deployment.yml
+++ b/helm-chart/templates/pdfgenerator-deployment.yml
@@ -17,6 +17,10 @@ spec:
         {{- include "avatar.labels" . | nindent 8 }}
         app.kubernetes.io/component: pdfgenerator
     spec:
+      {{- if .Values.pdfgenerator.tolerations }}
+      tolerations:
+        {{- toYaml .Values.pdfgenerator.tolerations | nindent 8 }}
+      {{ end -}}
       {{ if .Values.resources.pdfgeneratorPreferredNodeType }}
       affinity:
         nodeAffinity:

--- a/helm-chart/templates/scaled-objects.yaml
+++ b/helm-chart/templates/scaled-objects.yaml
@@ -28,11 +28,10 @@ spec:
           app.kubernetes.io/component: job
       spec:
         terminationGracePeriodSeconds: 3600 # We set it that high because we want to give the pod enough time to finish the task
+        {{- if $component.tolerations }}
         tolerations:
-          # Allow this pod to be scheduled on tainted nodes with a key of "highMemory"
-          # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration
-        - key: "highMemory"
-          operator: "Exists"
+          {{- toYaml $component.tolerations | nindent 10 }}
+        {{ end -}}
         affinity:
         # Force this pod to be scheduled on a node with the appropriate key defined in `preferredNodeType`.
         {{ if $component.preferredNodeType }}

--- a/helm-chart/templates/worker-deployment.yaml
+++ b/helm-chart/templates/worker-deployment.yaml
@@ -19,11 +19,10 @@ spec:
     spec:
       terminationGracePeriodSeconds: 3600 # We set it that high because we want to give the pod enough time to finish the task
       serviceAccountName: {{ .Values.gcp.ksaName | default "" | quote }}
+      {{- if .Values.worker.tolerations }}
       tolerations:
-        # Allow this pod to be scheduled on tainted nodes with a key of "highMemory"
-        # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration
-      - key: "highMemory"
-        operator: "Exists"
+        {{- toYaml .Values.worker.tolerations | nindent 8 }}
+      {{ end -}}
       {{ if .Values.resources.workerPreferredNodeType }}
       affinity:
         nodeAffinity:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -39,6 +39,9 @@ resources:
 redisHost: "127.0.0.1"
 redisPort: 6379
 
+pdfgenerator:
+  tolerations: [] # example: [{key: "exampleKey", operator: "Exists"}]
+# TODO: Nest these in a pdfgenerator: subsection
 pdfgeneratorHost: "avatar-pdf"
 pdfgeneratorPort: 8001
 
@@ -64,8 +67,16 @@ debug:
     useLocal: false
 
 worker:
-  useKedaAutoscaler: false
+  # These are the tolerations for the worker-deplotment.yaml that runs continuously
+  # on a specific node.
+  tolerations: [{key: "highMemory", operator: "Exists"}] # example: [{key: "exampleKey", operator: "Exists"}]
   preventPodsFromBeingScheduledOnSameNodeAsAPI: true
+
+  # If true, the worker will use KEDA to autoscale the number of pods based on the number of tasks in the queue.
+  useKedaAutoscaler: false
+
+  # The following values are used to set the configuration options for the autoscaling.
+  # Only used if useKedaAutoscaler is true.
   scaling:
     maxReplicaCount: 10
     scaledComponents:
@@ -73,13 +84,19 @@ worker:
         preferredNodeType: ""
         memoryRequest: "32Gi"
         queue: "medium"
+        tolerations: [{key: "highMemory", operator: "Exists"}] # example: [{key: "exampleKey", operator: "Exists"}]
       - identifier: "huge"
         preferredNodeType: ""
         memoryRequest: "64Gi"
         queue: "huge"
-
+        tolerations: [{key: "highMemory", operator: "Exists"}] # example: [{key: "exampleKey", operator: "Exists"}]
 
 api:
+  tolerations: [] # example: [{key: "exampleKey", operator: "Exists"}]
+  # TODO: Nest all of these in a config: subsection,
+  #       as this is the config that is used for the API app,
+  #       not only the API deployment/pod.
+  #       This will require modifying the values in the pulumi program
   # Externally accessible API url (should be with https)
   baseUrl: https://avatar.yourcompany.com
 


### PR DESCRIPTION
Tolerations (on pods) allows pods to be scheduled on nodes with a taint.
If a specific pod doesn't have the corresponding tolerations to a tainted node, it won't be scheduled.

This is used so that we can better control which pods go where in our cluster, without relying on an implicit coupling of the `highMemory` key being present.

In our pulumi program, we can now pass in the `tolerations` manually if we want.